### PR TITLE
{refactor} 사용자 정보와 날짜를 기반으로 매칭 정보 업데이트 및 취소 로직 변경

### DIFF
--- a/festi/src/main/java/com/gdg/festi/Match/Controller/MatchController.java
+++ b/festi/src/main/java/com/gdg/festi/Match/Controller/MatchController.java
@@ -33,15 +33,15 @@ public class MatchController {
     }
 
     // 매칭 등록 내역 수정
-    @PutMapping("/match/{matchId}")
-    public ApiResponse<?> putMatch(@PathVariable Long matchId, @RequestBody MatchInfoUpdateRequest matchInfoUpdateRequest) {
-        return matchService.updateMatchInfo(matchId, matchInfoUpdateRequest);
+    @PutMapping("/match/{day}")
+    public ApiResponse<?> putMatch(@LoginUser UserDetails userDetails, @PathVariable String day, @RequestBody MatchInfoUpdateRequest matchInfoUpdateRequest) {
+        return matchService.updateMatchInfo(userDetails, LocalDate.parse(day), matchInfoUpdateRequest);
     }
 
     // 매칭 등록 취소
-    @DeleteMapping("/match/{matchId}")
-    public ApiResponse<?> cancelMatch(@PathVariable Long matchId) {
-        return matchService.cancelMatchInfo(matchId);
+    @DeleteMapping("/match/{day}")
+    public ApiResponse<?> cancelMatch(@LoginUser UserDetails userDetails, @PathVariable String day) {
+        return matchService.cancelMatchInfo(userDetails, LocalDate.parse(day));
     }
 
     // 매칭 결과 조회

--- a/festi/src/main/java/com/gdg/festi/Match/Domain/MatchInfo.java
+++ b/festi/src/main/java/com/gdg/festi/Match/Domain/MatchInfo.java
@@ -1,5 +1,6 @@
 package com.gdg.festi.Match.Domain;
 
+import com.gdg.festi.Match.Dto.request.MatchInfoUpdateRequest;
 import com.gdg.festi.Match.Enums.Drink;
 import com.gdg.festi.Match.Enums.Gender;
 import com.gdg.festi.Match.Enums.Mood;
@@ -112,6 +113,54 @@ public class MatchInfo {
 
     public void updateModifiedAt(LocalDateTime modified_at) {
         this.modifiedAt = modified_at;
+    }
+
+    public void updateMatch(MatchInfoUpdateRequest matchInfoUpdateRequest) {
+        if (!this.groupName.equals(matchInfoUpdateRequest.getGroupName())) {
+            this.updateGroupName(matchInfoUpdateRequest.getGroupName());
+        }
+
+        if (!this.groupInfo.equals(matchInfoUpdateRequest.getGroupInfo())) {
+            this.updateGroupInfo(matchInfoUpdateRequest.getGroupInfo());
+        }
+
+        if (!this.people.equals(matchInfoUpdateRequest.getPeople())) {
+            this.updatePeople(matchInfoUpdateRequest.getPeople());
+        }
+
+        if (!this.matchDate.equals(matchInfoUpdateRequest.getMatchDate())) {
+            this.updateMatchDate(matchInfoUpdateRequest.getMatchDate());
+        }
+
+        if (!this.startTime.equals(matchInfoUpdateRequest.getStartTime())) {
+            this.updateStartTime(matchInfoUpdateRequest.getStartTime());
+        }
+
+        if (!this.gender.equals(matchInfoUpdateRequest.getGender())) {
+            this.updateGender(matchInfoUpdateRequest.getGender());
+        }
+
+        if (!this.desiredGender.equals(matchInfoUpdateRequest.getDesiredGender())) {
+            this.updateDesired_gender(matchInfoUpdateRequest.getDesiredGender());
+        }
+
+        if (!this.drink.equals(matchInfoUpdateRequest.getDrink())) {
+            this.updateDrink(matchInfoUpdateRequest.getDrink());
+        }
+
+        if (!this.mood.equals(matchInfoUpdateRequest.getMood())) {
+            this.updateMood(matchInfoUpdateRequest.getMood());
+        }
+
+        if (!this.contact.equals(matchInfoUpdateRequest.getContact())) {
+            this.updateContact(matchInfoUpdateRequest.getContact());
+        }
+
+        if (!this.groupImg.equals(matchInfoUpdateRequest.getGroupImg())) {
+            this.updateGroupImg(matchInfoUpdateRequest.getGroupImg());
+        }
+
+        this.updateModifiedAt(LocalDateTime.now());
     }
 
 }

--- a/festi/src/main/java/com/gdg/festi/Match/Service/MatchService.java
+++ b/festi/src/main/java/com/gdg/festi/Match/Service/MatchService.java
@@ -63,9 +63,11 @@ public class MatchService {
     }
 
     // 매칭 정보 수정
-    public ApiResponse<MatchInfoResponse> updateMatchInfo(Long match_info_id, MatchInfoUpdateRequest matchInfoUpdateRequest){
+    public ApiResponse<MatchInfoResponse> updateMatchInfo(UserDetails userDetails, LocalDate match_date, MatchInfoUpdateRequest matchInfoUpdateRequest){
 
-        MatchInfo matchInfo = matchInfoRepository.findById(match_info_id)
+        User loginUser = getLoginUser(userDetails);
+
+        MatchInfo matchInfo = matchInfoRepository.findByUserAndMatchDate(loginUser, match_date)
                 .orElseThrow(() -> new IllegalArgumentException("해당 매칭 정보가 없습니다."));
 
         updateInfo(matchInfo, matchInfoUpdateRequest);
@@ -74,9 +76,11 @@ public class MatchService {
     }
 
     // 매칭 등록 취소
-    public ApiResponse<?> cancelMatchInfo(Long match_info_id){
+    public ApiResponse<?> cancelMatchInfo(UserDetails userDetails, LocalDate match_date){
 
-        MatchInfo matchInfo = matchInfoRepository.findById(match_info_id)
+        User loginUser = getLoginUser(userDetails);
+
+        MatchInfo matchInfo = matchInfoRepository.findByUserAndMatchDate(loginUser, match_date)
                 .orElseThrow(() -> new IllegalArgumentException("해당 매칭 정보가 없습니다."));
 
         matchInfo.updateStatus(Status.CANCELED);
@@ -98,53 +102,7 @@ public class MatchService {
 
     // 매칭 정보 수정
     private void updateInfo(MatchInfo matchInfo, MatchInfoUpdateRequest matchInfoUpdateRequest) {
-
-        if (!matchInfo.getGroupName().equals(matchInfoUpdateRequest.getGroupName())) {
-            matchInfo.updateGroupName(matchInfoUpdateRequest.getGroupName());
-        }
-
-        if (!matchInfo.getGroupInfo().equals(matchInfoUpdateRequest.getGroupInfo())) {
-            matchInfo.updateGroupInfo(matchInfoUpdateRequest.getGroupInfo());
-        }
-
-        if (!matchInfo.getPeople().equals(matchInfoUpdateRequest.getPeople())) {
-            matchInfo.updatePeople(matchInfoUpdateRequest.getPeople());
-        }
-
-        if (!matchInfo.getMatchDate().equals(matchInfoUpdateRequest.getMatchDate())) {
-            matchInfo.updateMatchDate(matchInfoUpdateRequest.getMatchDate());
-        }
-
-        if (!matchInfo.getStartTime().equals(matchInfoUpdateRequest.getStartTime())) {
-            matchInfo.updateStartTime(matchInfoUpdateRequest.getStartTime());
-        }
-
-        if (!matchInfo.getGender().equals(matchInfoUpdateRequest.getGender())) {
-            matchInfo.updateGender(matchInfoUpdateRequest.getGender());
-        }
-
-        if (!matchInfo.getDesiredGender().equals(matchInfoUpdateRequest.getDesiredGender())) {
-            matchInfo.updateDesired_gender(matchInfoUpdateRequest.getDesiredGender());
-        }
-
-        if (!matchInfo.getDrink().equals(matchInfoUpdateRequest.getDrink())) {
-            matchInfo.updateDrink(matchInfoUpdateRequest.getDrink());
-        }
-
-        if (!matchInfo.getMood().equals(matchInfoUpdateRequest.getMood())) {
-            matchInfo.updateMood(matchInfoUpdateRequest.getMood());
-        }
-
-        if (!matchInfo.getContact().equals(matchInfoUpdateRequest.getContact())) {
-            matchInfo.updateContact(matchInfoUpdateRequest.getContact());
-        }
-
-        if (!matchInfo.getGroupImg().equals(matchInfoUpdateRequest.getGroupImg())) {
-            matchInfo.updateGroupImg(matchInfoUpdateRequest.getGroupImg());
-        }
-
-        matchInfo.updateModifiedAt(LocalDateTime.now());
-
+        matchInfo.updateMatch(matchInfoUpdateRequest);
     }
 
     private boolean isEnrolled(User user, LocalDate matchDate) {


### PR DESCRIPTION
# 매칭 정보 수정 및 삭제 관련 URI 수정
- 기존 매칭 ID 대신 매칭 날짜를 URI에 포함하여 요청하도록 수정
- 해당 유저의 정보와 매칭 날짜를 바탕으로 매칭을 찾고 반환하도록 로직 수정